### PR TITLE
Declared properties, added PHPDoc, removed closing ?> on all files, a…

### DIFF
--- a/Attachment.php
+++ b/Attachment.php
@@ -1,15 +1,35 @@
 <?php
 
+/**
+ * Class Attachment
+ */
 class Attachment extends PostController {
+
+  /**
+   * @var string $post_type
+   */
   protected static
     $post_type  = 'attachment';
 
+  /**
+   * @var string $description
+   * @var string $caption
+   * @var string $alt
+   * @var string $mime_type
+   * @var string $link
+   */
   public
     $description,
     $caption,
-    $link,
-    $alt;
+    $alt,
+    $mime_type,
+    $link;
 
+  /**
+   * Attachment constructor.
+   *
+   * @param WP_Post $post
+   */
   protected function __construct($post) {
     parent::__construct($post);
 
@@ -20,13 +40,17 @@ class Attachment extends PostController {
     // Retrieve post meta
     $this->alt        = get_post_meta($this->id, '_wp_attachment_image_alt', true);
     $this->mime_type  = get_post_mime_type($this->id);
-    $this->link        = wp_get_attachment_url($this->id);
+    $this->link       = wp_get_attachment_url($this->id);
   }
 
+  /**
+   * @return string
+   */
   public function file_type() {
     $type = explode('/', $this->mime_type);
     return empty($type[1]) ? '' : strtoupper($type[1]);
   }
+
 }
 
-?>
+

--- a/Meta.php
+++ b/Meta.php
@@ -1,16 +1,37 @@
 <?php
+
+/**
+ * Class Meta
+ */
 class Meta {
+
+  /**
+   * @var int $object_id
+   * @var string $object_type
+   * @var array $data
+   */
   private
     $object_id,
     $object_type,
     $data = array();
 
+  /**
+   * Meta constructor.
+   *
+   * @param int $id
+   * @param string $type
+   */
   public function __construct($id, $type) {
     $this->object_id = $id;
     $this->object_type = $type;
   }
 
-  // Magic methods
+  /**
+   * @param string $name
+   * @param array $arguments
+   *
+   * @return mixed
+   */
   public function __call($name, $arguments) {
     $this->get_meta($name);
 
@@ -32,6 +53,11 @@ class Meta {
     }
   }
 
+  /**
+   * @param string $name
+   *
+   * @return mixed
+   */
   public function __get($name) {
     $this->get_meta($name);
 
@@ -40,10 +66,18 @@ class Meta {
       : $this->data[$name];
   }
 
+  /**
+   * @param string $name
+   *
+   * @return bool
+   */
   public function __isset($name) {
     return isset($this->data[$name]);
   }
 
+  /**
+   * @param string $name
+   */
   public function __unset($name) {
     unset($this->data[$name]);
   }
@@ -59,6 +93,11 @@ class Meta {
     $this->get_meta($key, $name);
   }
 
+  /**
+   * @param string $key
+   * @param null $name
+   * @param bool|false $single
+   */
   private function get_meta($key, $name = null, $single = false) {
     $name = is_null($name) ? $key : $name;
     if ( isset($this->data[$name]) ) return;
@@ -76,15 +115,29 @@ class Meta {
     }
   }
 
-  // Meta functions
+  /**
+   * @param array $value
+   *
+   * @return mixed|null
+   */
   private function single($value) {
     return isset($value[0]) ? $value[0] : null;
   }
 
+  /**
+   * @param string $key
+   *
+   * @return mixed|null
+   */
   private function all($key) {
     return $this->data[$key];
   }
 
+  /**
+   * @param array $values
+   *
+   * @return array
+   */
   private function images($values) {
     if ( is_array($values) ) {
       return get_picture_controllers($values);
@@ -93,6 +146,11 @@ class Meta {
     }
   }
 
+  /**
+   * @param array $values
+   *
+   * @return PostController
+   */
   private function image($values) {
     if ( is_array($values) && isset($values[0]) ) {
       return get_picture_controller($values[0]);
@@ -102,4 +160,4 @@ class Meta {
   }
 
 }
-?>
+

--- a/Page.php
+++ b/Page.php
@@ -1,9 +1,20 @@
 <?php
 
+/**
+ * Class Page
+ */
 class Page extends PostController {
+
+  /**
+   * @var string $post_type
+   */
   protected static
     $post_type = 'page';
 
+  /**
+   * @var PostController $_parent
+   * @var PostController[] $_children
+   */
   protected
     $_parent,
     $_children;
@@ -30,7 +41,7 @@ class Page extends PostController {
    */
   public function parent() {
     if ( $this->_parent ) return $this->_parent;
-    if ( $this->post->post_parent == 0 ) return;
+    if ( $this->post->post_parent == 0 ) return null;
 
     return $this->_parent = self::get_controller($this->post->post_parent);
   }
@@ -54,6 +65,7 @@ class Page extends PostController {
   /**
    * Returns only top-level pages
    * @param array $args (optional)
+   * @return array
    */
   public static function get_base_pages($args = array()) {
     $args['hierarchical'] = false;
@@ -66,6 +78,7 @@ class Page extends PostController {
    * Returns pages of specified template(s)
    * @param array|string $templates
    * @param array $options (optional)
+   * @return array
    */
   public static function get_page_templates($templates, $options = array()) {
     $options = array_merge_recursive($options, array(
@@ -92,4 +105,4 @@ class Page extends PostController {
   }
 
 }
-?>
+

--- a/Picture.php
+++ b/Picture.php
@@ -1,10 +1,24 @@
 <?php
 
+/**
+ * Class Picture
+ */
 class Picture extends Attachment {
-  protected static $post_type = 'image';
 
+  /**
+   * @var string $post_type
+   */
+  protected static $post_type = 'image';
+  /**
+   * @var array $sizes
+   */
   public $sizes = array();
 
+  /**
+   * @param string $size
+   *
+   * @return mixed
+   */
   public function details($size) {
     if ( !isset($this->sizes[$size]) )
       $this->sizes[$size] = wp_get_attachment_image_src($this->id, $size);
@@ -12,24 +26,44 @@ class Picture extends Attachment {
     return $this->sizes[$size];
   }
 
+  /**
+   * @param string $size
+   *
+   * @return string
+   */
   public function src($size) {
     $details = $this->details($size);
     return $details[0];
   }
 
+  /**
+   * @param string $size
+   *
+   * @return int
+   */
   public function width($size) {
     $details = $this->details($size);
     return $details[1];
   }
 
+  /**
+   * @param string $size
+   *
+   * @return int
+   */
   public function height($size) {
     $details = $this->details($size);
     return $details[2];
   }
 
+  /**
+   * @param string $size
+   *
+   * @return bool
+   */
   public function is_resized($size) {
     $details = $this->details($size);
     return $details[3];
   }
 };
-?>
+

--- a/Post.php
+++ b/Post.php
@@ -1,10 +1,15 @@
 <?php
 /**
+ * Class Post
+ *
  * Built in post type
  */
-class Post extends PostController
-{
+class Post extends PostController {
+
+  /**
+   * @var string $post_type
+   */
   protected static
     $post_type = 'post';
 }
-?>
+

--- a/PostController.php
+++ b/PostController.php
@@ -21,7 +21,8 @@ class PostController {
   private static
     $post_type      = 'post',
     $post_types     = array(),
-    $page_templates = array();
+    $page_templates = array(),
+    $page_template  = null;
 
   /**
    * @var object $post WP_Post class
@@ -30,11 +31,48 @@ class PostController {
     $post;
 
   /**
+   * @var object $post WP_Post class
+   * @var int    id
+   * @var string slug
+   * @var string title
+   * @var string excerpt
+   * @var string content
+   * @var string status
+   * @var string type
+   * @var int    author
+   * @var int    menu_order
+   * @var int    comment_count
+   * @var string comment_status
+   * @var string date
+   * @var string date_gmt
+   * @var string modified
+   * @var string modified_gmt
+   * @var Meta   meta
+   */
+  public
+	$id,
+	$slug,
+	$title,
+	$excerpt,
+	$content,
+	$status,
+	$type,
+	$author,
+	$menu_order,
+	$comment_count,
+	$comment_status,
+	$date,
+	$date_gmt,
+	$modified,
+	$modified_gmt,
+    $meta;
+
+  /**
    * Retrieves the controller for the post type
    * @since 0.7.0
-   * @param string|int|object $post id, slug, or WP_Post object
+   * @param string|int|object $key post id, slug, or WP_Post object
    * @param array $options
-   * @return Controller
+   * @return PostController
    */
   public static function get_controller($key = null, $options = array()) {
     if ( is_null($key) ) {
@@ -233,8 +271,15 @@ class PostController {
 
   /**
    * Returns adjacent post controller.
+   *
    * @see https://codex.wordpress.org/Function_Reference/get_adjacent_post
-   * @return controller|false Returns controller if available, and false if no post
+   *
+   * @param bool|false $same_term
+   * @param array $excluded_terms
+   * @param bool|true $previous
+   * @param string $taxonomy
+   *
+   * @return PostController|false Returns controller if available, and false if no post
    */
   protected function adjacent_post($same_term = false, $excluded_terms = array(), $previous = true, $taxonomy = 'category') {
     $date_type = $previous ? 'before' : 'after';
@@ -373,8 +418,8 @@ class PostController {
    * @since 0.1.0
    * @param string $post_type
    * @param string|array $taxonomies
-   * @param array options (optional)
-   * @return array of controllers
+   * @param array $options (optional)
+   * @return array|null of controllers
    */
   public function related_posts($post_type, $taxonomies, $options = null) {
     $options = wp_parse_args( $options, array(
@@ -400,7 +445,7 @@ class PostController {
 
     foreach($taxonomies as $index => $taxonomy) {
       // Retrieve terms and continue if empty
-      $terms = $this->terms($taxonomy, false);
+      $terms = $this->terms($taxonomy);
       if ( is_null($terms) ) continue;
 
       // Store the ids into an array
@@ -416,7 +461,7 @@ class PostController {
     }
 
     if ( count($args['tax_query']) === 1 )
-      return;
+      return null;
 
     return self::get_controllers($args);
   }
@@ -424,12 +469,12 @@ class PostController {
   /**
    * Returns the featured image
    * @since 0.1.0
-   * @param string $size (optional)
+   * @param array $options (optional)
    * @return object|null
    */
   public function featured_image($options = array()) {
     $id = get_post_thumbnail_id($this->id);
-    if ( $id ) return get_picture_controller($id, $options);
+    return $id ? get_picture_controller( $id, $options ) : null;
   }
 
   /**
@@ -592,4 +637,3 @@ class PostController {
   }
 };
 
-?>

--- a/Term.php
+++ b/Term.php
@@ -165,7 +165,7 @@ class Term {
    */
   protected function __construct($term) {
     // Load all the term properties
-    foreach(get_class_vars($term) as $key => $value)
+    foreach(get_object_vars($term) as $key => $value)
       $this->$key = $value;
 
     // Extra properties

--- a/User.php
+++ b/User.php
@@ -1,11 +1,56 @@
 <?php
 
+/**
+ * Class User
+ */
 class User {
+
+  /**
+   *
+   */
   const CACHE_GROUP = 'usercontroller';
 
+  /**
+   * @var User $user
+   */
   protected
     $user;
 
+  /**
+   * @var int    $id
+   * @var array  $capabilities
+   * @var array  $roles
+   * @var array  $all_capabilities
+   * @var string $display_name
+   * @var string $nice_name
+   * @var string $login
+   * @var string $email
+   * @var string $status
+   * @var bool   $registered
+   * @var string $first_name
+   * @var string $last_name
+   * @var string $description
+   * @var Meta   $meta
+   */
+  public
+    $id,
+    $capabilities,
+    $roles,
+    $all_capabilities,
+    $display_name,
+    $nice_name,
+    $login,
+    $email,
+    $status,
+    $registered,
+    $first_name,
+    $last_name,
+    $description,
+    $meta;
+
+  /**
+   *
+   */
   public static function _construct() {
     if ( __CLASS__ === get_called_class() ) {
       add_action('profile_update', array(__CLASS__, 'profile_update'), 10, 2);
@@ -68,6 +113,11 @@ class User {
     return $controller;
   }
 
+  /**
+   * @param WP_User[] $args
+   *
+   * @return User[]
+   */
   public static function get_controllers($args) {
     $users = get_users($args);
     $controllers = array();
@@ -77,15 +127,26 @@ class User {
     return $controllers;
   }
 
+  /**
+   * @param int $user_id
+   * @param WP_User $old_user
+   */
   public static function profile_update($user_id, $old_user) {
     self::clear_controller_cache($old_user);
   }
 
+  /**
+   * @param int $user_id
+   * @param int $reassign_id
+   */
   public static function delete_user($user_id, $reassign_id) {
     $user = get_user_by('id', $user_id);
     if ( $user ) self::clear_controller_cache($user);
   }
 
+  /**
+   * @param WP_User $user
+   */
   public static function clear_controller_cache($user) {
     wp_cache_delete($user->ID, self::CACHE_GROUP);
     wp_cache_delete($user->data->user_email, self::CACHE_GROUP . '_email');
@@ -93,6 +154,12 @@ class User {
     wp_cache_delete($user->data->user_login, self::CACHE_GROUP . '_login');
   }
 
+  /**
+   * User constructor.
+   *
+   * @param WP_User $user
+   * @param bool $load_extra
+   */
   protected function __construct($user, $load_extra) {
     $this->user = $user;
 
@@ -119,16 +186,29 @@ class User {
     $this->meta = new Meta($this->id, 'post');
   }
 
+  /**
+   * @param string $format
+   *
+   * @return bool|int|string
+   */
   public function registered($format) {
     return ( 'timestamp' === $format )
       ? strtotime($this->registered)
       : date($format, strtotime($this->registered));
   }
 
+  /**
+   * @return string
+   */
   public function posts_url() {
     return get_author_posts_url($this->id);
   }
 
+  /**
+   * @param string[]|string|null $post_types
+   *
+   * @return User[]
+   */
   public static function get_authors($post_types = null) {
     global $wpdb;
 
@@ -159,6 +239,12 @@ class User {
     return $authors;
   }
 
+  /**
+   * @param int[] $user_ids
+   * @param null $post_type
+   *
+   * @return array
+   */
   public static function get_users_post_count($user_ids, $post_type = null) {
     $user_ids = ( $user_ids ) ? $user_ids : get_users();
     $post_type = ( $post_type ) ? $post_type : get_post_types();
@@ -180,4 +266,3 @@ class User {
     }
   }
 };
-?>

--- a/autoload.php
+++ b/autoload.php
@@ -3,7 +3,9 @@
  * Autoload classes and functions
  */
 
-// Register autoloader
+/*
+ * Register autoloader
+ */
 $directory = __DIR__;
 spl_autoload_register(function($class) use ($directory) {
   if ( !file_exists("$directory/$class.php") ) return;
@@ -14,7 +16,9 @@ spl_autoload_register(function($class) use ($directory) {
   }
 });
 
-// Load all controller files
+/*
+ * Load all controller files
+ */
 $_files = scandir($directory);
 $_autoload_file = basename(__FILE__);
 foreach($_files as $_file) {
@@ -29,6 +33,11 @@ if ( !function_exists('get_post_controller') ) {
   /**
    * Global function to call PostController::get_controller
    * @see PostController::get_controller
+   *
+   * @param string|null $key
+   * @param array $options
+   *
+   * @return PostController
    */
   function get_post_controller($key = null, $options = array()) { return PostController::get_controller($key, $options); }
 }
@@ -37,6 +46,10 @@ if ( !function_exists('get_post_controllers') ) {
   /**
    * Global function to call PostController::get_controllers
    * @see PostController::get_controllers
+   *
+   * @param array $args
+   *
+   * @return array
    */
   function get_post_controllers($args = null) { return PostController::get_controllers($args); }
 }
@@ -45,6 +58,11 @@ if ( !function_exists('get_page_controller') ) {
   /**
    * Global function to call Page::get_controller
    * @see PostController::get_controller
+   *
+   * @param string|null $key
+   * @param array $options
+   *
+   * @return PostController
    */
   function get_page_controller($key = null, $options = array()) { return Page::get_controller($key, $options); }
 }
@@ -53,6 +71,10 @@ if ( !function_exists('get_page_controllers') ) {
   /**
    * Global function to call Page::get_controllers
    * @see PostController::get_controllers
+   *
+   * @param array $args
+   *
+   * @return array
    */
   function get_page_controllers($args = null) { return Page::get_controllers($args); }
 }
@@ -61,6 +83,11 @@ if ( !function_exists('get_picture_controller') ) {
   /**
    * Global function to call Picture::get_controllers
    * @see PostController::get_controller
+   *
+   * @param string|null $key
+   * @param array $options
+   *
+   * @return PostController
    */
   function get_picture_controller($key = null, $options = array()) { return Picture::get_controller($key, $options); }
 }
@@ -69,6 +96,12 @@ if ( !function_exists('get_term_controller') ) {
   /**
    * Global function to call Term::get_controller
    * @see Term::get_controller
+   *
+   * @param string|null $key
+   * @param string $field
+   * @param array $options
+   *
+   * @return Term
    */
   function get_term_controller($key = null, $taxonomy = null, $field = 'id', $options = array()) {
     return Term::get_controller($key, $taxonomy, $field, $options);
@@ -79,6 +112,12 @@ if ( !function_exists('get_user_controller') ) {
   /**
    * Global function to calll User::get_controller
    * @see User::get_controller
+   *
+   * @param string|null $key
+   * @param string $field
+   * @param array $options
+   *
+   * @return User
    */
   function get_user_controller($key = null, $field = 'id', $options = array()) { return User::get_controller($key, $field, $options); }
 }
@@ -87,8 +126,24 @@ if ( !function_exists('get_user_controllers') ) {
   /**
    * Global function to calll User::get_controllers
    * @see User::get_controllers
+   *
+   * @param array $args
+   *
+   * @return array
    */
   function get_user_controllers($args) { return User::get_controllers($args); }
 }
 
-?>
+if ( !function_exists('get_picture_controllers') ) {
+  /**
+   * Global function to calll User::get_controllers
+   * @see Picture::get_controllers
+   *
+   * @param array $args
+   *
+   * @return array
+   */
+  function get_picture_controllers($args) { return Picture::get_controllers($args); }
+}
+
+


### PR DESCRIPTION
1. Declared properties
2. Added PHPDoc
3. [Removed closing `?>` on all files](http://hardcorewp.com/2013/always-omit-closing-php-tags-in-wordpress-plugins/)
4. In `Term.php`: 
   - sanitized a SQL query 
   - added missing `$wpdb->`
   - in `Term`'s `__construct()` 
     - Added `get_object_vars()` on `foreach`
     - Changed to `$term->` instead of `$this->` as appropriate
