### PR TITLE
Change autoloading system to load on-the-fly in WordPress fashion

### DIFF
--- a/controllers/Picture.php
+++ b/controllers/Picture.php
@@ -5,11 +5,6 @@
  */
 class Picture extends Attachment {
   /**
-   * @var string $post_type
-   */
-  public static $controller_post_type = 'image';
-
-  /**
    * @var array $sizes
    * @var boolean $is_image
    */

--- a/controllers/Post.php
+++ b/controllers/Post.php
@@ -14,6 +14,12 @@
  */
 class Post {
   /**
+   * @var string $post_type
+   */
+  public static
+    $controller_post_type = 'post';
+    
+  /**
    * @var array $_controller_templates        template_slug => controller
    * @var array $_controller_post_types       post_type => controller
    */
@@ -228,14 +234,14 @@ class Post {
 
     } else {
       $data = get_file_data(get_template_directory() . "/$template", array(
-        'controller_class' => 'WP Controller Class'
+        'controller_class' => 'WP Controller'
       ));
 
       $class = $data['controller_class'];
 
       if ( is_child_theme() ) {
         $data = get_file_data(get_stylesheet_directory() . "/$template", array(
-          'controller_class' => 'WP Controller Class'
+          'controller_class' => 'WP Controller'
         ));
 
         $class = !empty($data['controller_class']) ? $data['controller_class'] : $class;

--- a/wp-controllers.php
+++ b/wp-controllers.php
@@ -19,6 +19,7 @@ final class WP_Controllers_Plugin {
    */
   public static function _construct() {
     add_action('init', array(__CLASS__, 'init'));
+    add_filter('register_post_type_args', array(__CLASS__, 'register_post_type_args'), 10, 2);
   }
 
   /**
@@ -30,13 +31,25 @@ final class WP_Controllers_Plugin {
 
     spl_autoload_register(array(__CLASS__, 'autoload_register'));
 
-    foreach(self::$_directories as $directory) {
-      self::auto_load_controllers($directory);
+    require_once 'functions.php';
+  }
+
+  public static function register_post_type_args($args, $post_type) {
+    switch($post_type) {
+      case 'post':
+        $args['wp_controller_class'] = 'Post';
+        break;
+
+      case 'attachment':
+        $args['wp_controller_class'] = 'Attachment';
+        break;
+
+      case 'page':
+        $args['wp_controller_class'] = 'Page';
+        break;
     }
 
-    spl_autoload_unregister(array(__CLASS__, 'autoload_register'));
-
-    require_once 'functions.php';
+    return $args;
   }
 
   /**
@@ -102,24 +115,6 @@ final class WP_Controllers_Plugin {
         $directory = apply_filters('wp_controllers_plugin_directory', "$plugins_path/$path/wp-controllers", $path, $data);
         if ( is_dir($directory) ) {
           self::$_directories[] = $directory;
-        }
-      }
-    }
-  }
-
-  /**
-   * auto_load_controllers.
-   * Loads the controller classes for the given directory
-   * @param  string $directory absolute path to directory
-   */
-  private static function auto_load_controllers($directory) {
-    $files = scandir($directory);
-    if ( empty($files) ) return;
-
-    foreach($files as $file) {
-      if ( ( $class = strstr($file, '.php', true) ) ) {
-        if ( !class_exists($class) ) {
-          trigger_error("$file expected to load the $class class but $class was not found", E_USER_WARNING);
         }
       }
     }


### PR DESCRIPTION
This is for issue #6. The goal of this is three-fold:
1. Only load the controller classes that are actually used within a request
2. Take advantage of post and term registration to set the controller class in the same way that the REST API does, as part of the registration process.
3. Use template comment blocks to set the controller at that time